### PR TITLE
Widen unnecessary restrictive type of phases list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.1
+
+- Widened type of `phases` parameter of `testPhases` function, which allows
+  to use it to test aggregate transformers and transformer groups.
+
 ## 0.2.0
 
 - Changed all optional arguments to `testPhases` to named arguments.

--- a/lib/src/test_harness.dart
+++ b/lib/src/test_harness.dart
@@ -43,7 +43,7 @@ class TestHelper implements PackageProvider {
     return new Asset.fromString(id, files[idToString(id)]);
   }
 
-  TestHelper(List<List<Transformer>> transformers, Map<String, String> files,
+  TestHelper(List<List> transformers, Map<String, String> files,
       this.messages,
       {this.formatter: StringFormatter.noTrailingWhitespace,
       this.expectBarbackErrors: false})

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -19,7 +19,7 @@ import 'src/test_harness.dart';
 export 'src/test_harness.dart' show StringFormatter;
 
 /// Defines a test which invokes [applyTransformers].
-testPhases(String testName, List<List<Transformer>> phases,
+testPhases(String testName, List<List> phases,
     Map<String, String> inputs, Map<String, String> results,
     {List messages: const [],
     StringFormatter formatter: StringFormatter.noTrailingWhitespace,
@@ -46,7 +46,7 @@ testPhases(String testName, List<List<Transformer>> phases,
 ///
 /// If [messages] is non-null then this will validate that only the specified
 /// messages were generated, ignoring info messages.
-Future applyTransformers(List<List<Transformer>> phases,
+Future applyTransformers(List<List> phases,
     {Map<String, String> inputs: const {},
     Map<String, String> results: const {},
     List messages: const [],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: transformer_test
-version: 0.2.0
+version: 0.2.1
 description: A library which helps with writing tests for transformers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/transformer_test


### PR DESCRIPTION
The only thing `phases` is used for is to pass it to `Barback#updateTransformers`, which accepts `Iterable<Iterable>`, where inner `Iterable` can contain `Transformer`, `TransformerGroup` or `AggregateTransformer` and don't have common supertype.

Thus, making `phases` type to be `List<List<Transformers>>` unnecessarily restricts its usage. This CL loosens the type of `phases` to allow aggregate transformers and transformer groups to be passed as well.
